### PR TITLE
Move var.secrets into var.namespaces

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -107,8 +107,8 @@ variable "enable_public_endpoint" {
 variable "namespaces" {
   description = "A list of namespaces to be created in kubernetes. A map of secrets can be included e.g. {\"mysql\": {\"username\": \"johndoe\", \"password\": \"password123\"}}"
   type = list(object({
-    name   = string
-    labels = map(string)
+    name    = string
+    labels  = map(string)
     secrets = map(map(string))
   }))
   default = []

--- a/variables.tf
+++ b/variables.tf
@@ -105,18 +105,13 @@ variable "enable_public_endpoint" {
 }
 
 variable "namespaces" {
-  description = "A list of namespaces to be created in kubernetes."
+  description = "A list of namespaces to be created in kubernetes. A map of secrets can be included e.g. {\"mysql\": {\"username\": \"johndoe\", \"password\": \"password123\"}}"
   type = list(object({
     name   = string
     labels = map(string)
+    secrets = map(map(string))
   }))
   default = []
-}
-
-variable "secrets" {
-  description = "Set of secrets to be created in the different namespaces. Example- {\"namespacename:mysql\": {\"username\": \"johndoe\", \"password\": \"password123\"}}."
-  type        = map(map(string))
-  default     = {}
 }
 
 variable "enable_addon_http_load_balancing" {


### PR DESCRIPTION
Allows declaring secrets without having to repeat the namespace name for every single secret that is declared. This also reduces chances of typos and mistakes.

OLD WAY:
```terraform
module "gke_cluster" {
  source = "airasia/gke_cluster/google"
  ......
  ......
  ......
  ......
  ......
  namespaces = [
    {
      name   = "myns"
      labels = {}
    }
  ]
  secrets = {
    "myns:mysqldb" = {
      username = module.mysql_db.root_user_name
      password = module.mysql_db.root_user_password
    }
    "myns:postgresdb" = {
      username = module.postgres_db.root_user_name
      password = module.postgres_db.root_user_password
    }
    "myns:sqlserverdb" = {
      username = module.sqlserver_db.root_user_name
      password = module.sqlserver_db.root_user_password
    }
  }
}
```

NEW WAY
```terraform
module "gke_cluster" {
  source = "airasia/gke_cluster/google"
  ......
  ......
  ......
  ......
  ......
  namespaces = [
    {
      name   = "myns"
      labels = {}
      secrets = {
        mysqldb = {
          username = module.mysql_db.root_user_name
          password = module.mysql_db.root_user_password
        }
        postgresdb = {
          username = module.postgres_db.root_user_name
          password = module.postgres_db.root_user_password
        }
        sqlserverdb = {
          username = module.sqlserver_db.root_user_name
          password = module.sqlserver_db.root_user_password
        }
      }
    }
  ]
}
```