### PR TITLE
Isolate k8s provider definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,29 @@
 Terraform module for a GKE Kubernetes Cluster in GCP
 
+# Fixing kubernetes "connection refused" error
+
+If you are using the `namespace` variable, you may get an error like the following:
+
+```
+Error: Get "http://localhost/api/v1/namespaces/<namespace_name>": dial tcp 127.0.0.1:80: connect: connection refused
+```
+
+In order to fix this, you need to declare a `kubernetes` provider in your terraform configuration like the following.
+
+```terraform
+provider "kubernetes" {
+  version                = "1.13.3" # see https://github.com/terraform-providers/terraform-provider-kubernetes/releases
+  load_config_file       = false
+  host                   = module.gke_cluster.cluster_endpoint
+  token                  = data.google_client_config.google_client.access_token
+  cluster_ca_certificate = module.gke_cluster.cluster_ca_certificate
+}
+
+data "google_client_config" "google_client" {}
+```
+
+Pay attention to the `gke_cluster` module output variables used here.
+
 # Upgrade guide from v2.6.0 to v2.7.0
 
 This upgrade performs 2 changes:

--- a/main.tf
+++ b/main.tf
@@ -2,14 +2,6 @@ terraform {
   required_version = ">= 0.13.1" # see https://releases.hashicorp.com/terraform/
 }
 
-provider "kubernetes" {
-  version                = ">= 1.12.0" # see https://github.com/terraform-providers/terraform-provider-kubernetes/releases
-  load_config_file       = false
-  host                   = google_container_cluster.k8s_cluster.endpoint
-  token                  = data.google_client_config.google_client.access_token
-  cluster_ca_certificate = base64decode(google_container_cluster.k8s_cluster.master_auth.0.cluster_ca_certificate)
-}
-
 locals {
   cluster_name           = format("%s-%s", var.cluster_name, var.name_suffix)
   istioctl_firewall_name = format("%s-%s", var.istioctl_firewall_name, var.name_suffix)

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,3 +5,11 @@ output "usage_IAM_roles" {
     "roles/storage.objectViewer",
   ]
 }
+
+output "cluster_endpoint" {
+  value = google_container_cluster.k8s_cluster.endpoint
+}
+
+output "cluster_ca_certificate" {
+  value = base64decode(google_container_cluster.k8s_cluster.master_auth.0.cluster_ca_certificate)
+}


### PR DESCRIPTION
To use terraform's `count` keyword with a module, there must not be any `provider` definition **inside** the module itself

- Remove k8s provider and expose necessary cluster attributes as output
- Update readme