### PR TITLE
Add istio kiali ports

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -218,7 +218,10 @@ resource "google_compute_firewall" "istioctl_firewall" {
   allow {
     # see https://istio.io/latest/docs/setup/platform-setup/gke/
     protocol = "tcp"
-    ports    = ["10250", "443", "15017"]
+    ports = [
+      "10250", "443", "15017", # see https://istio.io/latest/docs/setup/platform-setup/gke/
+      "8080", "15000",         # see https://kiali.io/documentation/latest/installation-guide/#_google_cloud_private_cluster_requirements
+    ]
   }
 }
 


### PR DESCRIPTION
The newer versions of Kiali 1.18+ required additional ports for communication. Otherwise Kiali is not able to load service metrics and visualize the mesh.