### PR TITLE
Ignore current node count differences to avoid change-resolution for current state

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -151,7 +151,6 @@ resource "google_container_node_pool" "node_pools" {
   version            = local.gke_node_version
   cluster            = google_container_cluster.k8s_cluster.name
   initial_node_count = each.value.node_count_initial_per_zone
-  node_count         = each.value.node_count_current_per_zone
   max_pods_per_node  = each.value.max_pods_per_node
   autoscaling {
     min_node_count = each.value.node_count_min_per_zone

--- a/main.tf
+++ b/main.tf
@@ -180,6 +180,11 @@ resource "google_container_node_pool" "node_pools" {
       enable_integrity_monitoring = coalesce(each.value.enable_shielded_nodes, true)
     }
   }
+  lifecycle {
+    ignore_changes = [
+      initial_node_count # changes to this field triggers destruction/recreation. See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool#initial_node_count
+    ]
+  }
   depends_on = [google_project_service.container_api]
   timeouts {
     create = var.node_pool_timeout

--- a/variables.tf
+++ b/variables.tf
@@ -187,9 +187,9 @@ variable "node_pools" {
   description = <<-EOT
   node_pool_name: An arbitrary name to identify the GKE node pool and its VMs & VM instance groups.
   
-  node_count_initial_per_zone: Immutable. It is the initial number of nodes (per zone) for the node
-  pool to begin with. Should only be used during creation time as it is immutable - modifying it
-  later will force a recreation of the existing node_pool.
+  node_count_initial_per_zone: It is the initial number of nodes (per zone) for the node
+  pool to begin with. Should only be used during creation time as it is immutable. Subsequent
+  changes made to this value will be ignored.
   
   node_count_min_per_zone: The minimum number of nodes (per zone) this nodepool will allocate if
   auto-down-scaling occurs.

--- a/variables.tf
+++ b/variables.tf
@@ -189,17 +189,7 @@ variable "node_pools" {
   
   node_count_initial_per_zone: Immutable. It is the initial number of nodes (per zone) for the node
   pool to begin with. Should only be used during creation time as it is immutable - modifying it
-  later will force a recreation of the existing node_pool. Use "node_count_current_per_zone" instead
-  to modify current size after creation (if necessary).
-  
-  node_count_current_per_zone: Mutable. It must be "null" when creating the cluster for the first
-  time. It is mutable - can be changed later to modify the current number of nodes (per zone) as
-  long as the value is between "node_count_min_per_zone" and "node_count_max_per_zone" (inclusive).
-  If you must set the number of nodes upon initial creation, then use "node_count_initial_per_zone"
-  instead which is an immutable value. Do not modify the value of "node_count_current_per_zone"
-  WHILE modifying  "node_count_min_per_zone" or "node_count_max_per_zone". Run 2 separate
-  'terraformapply' commands to modify "node_count_min_per_zone"/"node_count_max_per_zone" in one
-  command and modify "node_count_current_per_zone" in another command.
+  later will force a recreation of the existing node_pool.
   
   node_count_min_per_zone: The minimum number of nodes (per zone) this nodepool will allocate if
   auto-down-scaling occurs.
@@ -241,7 +231,6 @@ variable "node_pools" {
   type = list(object({
     node_pool_name              = string
     node_count_initial_per_zone = number
-    node_count_current_per_zone = number
     node_count_min_per_zone     = number
     node_count_max_per_zone     = number
     node_labels                 = map(string)
@@ -257,7 +246,6 @@ variable "node_pools" {
   default = [{
     node_pool_name              = "gkenp-a"
     node_count_initial_per_zone = 1
-    node_count_current_per_zone = null
     node_count_min_per_zone     = 1
     node_count_max_per_zone     = 2
     node_labels                 = {}


### PR DESCRIPTION
Commit-by-commit

1. Do not set node_count_current_per_zone via IAC as changes to it are most often done via console.
2. Ignore changes to node_count_initial_per_zone as changes to it triggers destruction-recreation of node_pool