### PR TITLE
Ignore current/initial node count differences to avoid change-resolution on current state

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -152,7 +152,6 @@ resource "google_container_node_pool" "node_pools" {
   version            = local.gke_node_version
   cluster            = google_container_cluster.k8s_cluster.name
   initial_node_count = each.value.node_count_initial_per_zone
-  node_count         = each.value.node_count_current_per_zone
   max_pods_per_node  = each.value.max_pods_per_node
   autoscaling {
     min_node_count = each.value.node_count_min_per_zone

--- a/main.tf
+++ b/main.tf
@@ -182,6 +182,11 @@ resource "google_container_node_pool" "node_pools" {
       enable_integrity_monitoring = coalesce(each.value.enable_node_integrity, true)
     }
   }
+  lifecycle {
+    ignore_changes = [
+      initial_node_count # changes to this field triggers destruction/recreation. See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool#initial_node_count
+    ]
+  }
   depends_on = [google_project_service.container_api]
   timeouts {
     create = var.node_pool_timeout

--- a/main.tf
+++ b/main.tf
@@ -151,7 +151,7 @@ resource "google_container_node_pool" "node_pools" {
   location           = local.gke_location
   version            = local.gke_node_version
   cluster            = google_container_cluster.k8s_cluster.name
-  initial_node_count = each.value.node_count_initial_per_zone
+  initial_node_count = each.value.node_count_min_per_zone
   max_pods_per_node  = each.value.max_pods_per_node
   autoscaling {
     min_node_count = each.value.node_count_min_per_zone

--- a/variables.tf
+++ b/variables.tf
@@ -195,17 +195,7 @@ variable "node_pools" {
   
   node_count_initial_per_zone: Immutable. It is the initial number of nodes (per zone) for the node
   pool to begin with. Should only be used during creation time as it is immutable - modifying it
-  later will force a recreation of the existing node_pool. Use "node_count_current_per_zone" instead
-  to modify current size after creation (if necessary).
-  
-  node_count_current_per_zone: Mutable. It must be "null" when creating the cluster for the first
-  time. It is mutable - can be changed later to modify the current number of nodes (per zone) as
-  long as the value is between "node_count_min_per_zone" and "node_count_max_per_zone" (inclusive).
-  If you must set the number of nodes upon initial creation, then use "node_count_initial_per_zone"
-  instead which is an immutable value. Do not modify the value of "node_count_current_per_zone"
-  WHILE modifying  "node_count_min_per_zone" or "node_count_max_per_zone". Run 2 separate
-  'terraformapply' commands to modify "node_count_min_per_zone"/"node_count_max_per_zone" in one
-  command and modify "node_count_current_per_zone" in another command.
+  later will force a recreation of the existing node_pool.
   
   node_count_min_per_zone: The minimum number of nodes (per zone) this nodepool will allocate if
   auto-down-scaling occurs.
@@ -253,7 +243,6 @@ variable "node_pools" {
   type = list(object({
     node_pool_name              = string
     node_count_initial_per_zone = number
-    node_count_current_per_zone = number
     node_count_min_per_zone     = number
     node_count_max_per_zone     = number
     node_labels                 = map(string)
@@ -270,7 +259,6 @@ variable "node_pools" {
   default = [{
     node_pool_name              = "gkenp-a"
     node_count_initial_per_zone = 1
-    node_count_current_per_zone = null
     node_count_min_per_zone     = 1
     node_count_max_per_zone     = 2
     node_labels                 = {}

--- a/variables.tf
+++ b/variables.tf
@@ -237,34 +237,34 @@ variable "node_pools" {
   See https://cloud.google.com/kubernetes-engine/docs/how-to/shielded-gke-nodes#node_integrity
   EOT
   type = list(object({
-    node_pool_name              = string
-    node_count_min_per_zone     = number
-    node_count_max_per_zone     = number
-    node_labels                 = map(string)
-    node_taints                 = list(object({ key = string, value = string, effect = string }))
-    max_pods_per_node           = number
-    machine_type                = string
-    disk_type                   = string
-    disk_size_gb                = number
-    preemptible                 = bool
-    max_surge                   = number
-    max_unavailable             = number
-    enable_node_integrity       = bool
+    node_pool_name          = string
+    node_count_min_per_zone = number
+    node_count_max_per_zone = number
+    node_labels             = map(string)
+    node_taints             = list(object({ key = string, value = string, effect = string }))
+    max_pods_per_node       = number
+    machine_type            = string
+    disk_type               = string
+    disk_size_gb            = number
+    preemptible             = bool
+    max_surge               = number
+    max_unavailable         = number
+    enable_node_integrity   = bool
   }))
   default = [{
-    node_pool_name              = "gkenp-a"
-    node_count_min_per_zone     = 1
-    node_count_max_per_zone     = 2
-    node_labels                 = {}
+    node_pool_name          = "gkenp-a"
+    node_count_min_per_zone = 1
+    node_count_max_per_zone = 2
+    node_labels             = {}
     node_taints                 = []
-    max_pods_per_node           = 32
-    machine_type                = "e2-micro"
-    disk_type                   = "pd-standard"
-    disk_size_gb                = 50
-    preemptible                 = false
-    max_surge                   = 1
-    max_unavailable             = 0
-    enable_node_integrity       = null
+    max_pods_per_node       = 32
+    machine_type            = "e2-micro"
+    disk_type               = "pd-standard"
+    disk_size_gb            = 50
+    preemptible             = false
+    max_surge               = 1
+    max_unavailable         = 0
+    enable_node_integrity   = null
   }]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -193,9 +193,9 @@ variable "node_pools" {
   description = <<-EOT
   node_pool_name: An arbitrary name to identify the GKE node pool and its VMs & VM instance groups.
   
-  node_count_initial_per_zone: Immutable. It is the initial number of nodes (per zone) for the node
-  pool to begin with. Should only be used during creation time as it is immutable - modifying it
-  later will force a recreation of the existing node_pool.
+  node_count_initial_per_zone: It is the initial number of nodes (per zone) for the node
+  pool to begin with. Should only be used during creation time as it is immutable. Subsequent
+  changes made to this value will be ignored.
   
   node_count_min_per_zone: The minimum number of nodes (per zone) this nodepool will allocate if
   auto-down-scaling occurs.

--- a/variables.tf
+++ b/variables.tf
@@ -193,10 +193,6 @@ variable "node_pools" {
   description = <<-EOT
   node_pool_name: An arbitrary name to identify the GKE node pool and its VMs & VM instance groups.
   
-  node_count_initial_per_zone: It is the initial number of nodes (per zone) for the node
-  pool to begin with. Should only be used during creation time as it is immutable. Subsequent
-  changes made to this value will be ignored.
-  
   node_count_min_per_zone: The minimum number of nodes (per zone) this nodepool will allocate if
   auto-down-scaling occurs.
   
@@ -242,7 +238,6 @@ variable "node_pools" {
   EOT
   type = list(object({
     node_pool_name              = string
-    node_count_initial_per_zone = number
     node_count_min_per_zone     = number
     node_count_max_per_zone     = number
     node_labels                 = map(string)
@@ -258,7 +253,6 @@ variable "node_pools" {
   }))
   default = [{
     node_pool_name              = "gkenp-a"
-    node_count_initial_per_zone = 1
     node_count_min_per_zone     = 1
     node_count_max_per_zone     = 2
     node_labels                 = {}


### PR DESCRIPTION
Commit-by-commit

1. Do not set `node_count_current_per_zone` via IAC as changes to it are most often done via console.
2. add lifecycle rules to Ignore changes made to `initial_node_count` - as changes to it triggers destruction-recreation of node_pool
3. Remove ability to define `node_count_initial_per_zone`
   1. Internally set `initial_node_count` to equal to `node_count_min_per_zone`
      * this will be used for initial creation of the node-pool(s) only.
   2. For later modifications to node-pool(s), we have defined **lifecycle rules** above
      * this will ignore_changes made to the `initial_node_count` attribute
