### PR TITLE
Support for Node Taints

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ locals {
   cluster_firewall_name  = format("%s-%s", var.firewall_name, var.name_suffix)
   node_network_tags      = [format("gke-%s-np-tf-%s", local.cluster_name, random_string.network_tag_substring.result)]
   oauth_scopes           = ["cloud-platform"] # FULL ACCESS to all GCloud services. Limit them by IAM roles in 'gke_service_account' - see https://cloud.google.com/compute/docs/access/service-accounts#accesscopesiam
-  master_private_ip_cidr = "172.16.0.0/28"   # the cluster master's private IP will be assigned from this CIDR - https://cloud.google.com/nat/docs/gke-example#step_2_create_a_private_cluster
+  master_private_ip_cidr = "172.16.0.0/28"    # the cluster master's private IP will be assigned from this CIDR - https://cloud.google.com/nat/docs/gke-example#step_2_create_a_private_cluster
   pre_defined_sa_roles = [
     "roles/logging.logWriter",
     "roles/monitoring.metricWriter",

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ locals {
   cluster_firewall_name  = format("%s-%s", var.firewall_name, var.name_suffix)
   node_network_tags      = [format("gke-%s-np-tf-%s", local.cluster_name, random_string.network_tag_substring.result)]
   oauth_scopes           = ["cloud-platform"] # FULL ACCESS to all GCloud services. Limit them by IAM roles in 'gke_service_account' - see https://cloud.google.com/compute/docs/access/service-accounts#accesscopesiam
-  master_private_ip_cidr = "172.16.0.0/28"    # the cluster master's private IP will be assigned from this CIDR - https://cloud.google.com/nat/docs/gke-example#step_2_create_a_private_cluster 
+  master_private_ip_cidr = "172.16.0.32/28"   # the cluster master's private IP will be assigned from this CIDR - https://cloud.google.com/nat/docs/gke-example#step_2_create_a_private_cluster
   pre_defined_sa_roles = [
     "roles/logging.logWriter",
     "roles/monitoring.metricWriter",
@@ -175,6 +175,7 @@ resource "google_container_node_pool" "node_pools" {
     service_account = module.gke_service_account.email
     oauth_scopes    = local.oauth_scopes
     tags            = local.node_network_tags
+    taint           = each.value.node_taints
     shielded_instance_config {
       # set default values as per the defaults stated in google provider
       # see https://registry.terraform.io/providers/hashicorp/google/3.65.0/docs/resources/container_cluster

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ locals {
   cluster_firewall_name  = format("%s-%s", var.firewall_name, var.name_suffix)
   node_network_tags      = [format("gke-%s-np-tf-%s", local.cluster_name, random_string.network_tag_substring.result)]
   oauth_scopes           = ["cloud-platform"] # FULL ACCESS to all GCloud services. Limit them by IAM roles in 'gke_service_account' - see https://cloud.google.com/compute/docs/access/service-accounts#accesscopesiam
-  master_private_ip_cidr = "172.16.0.0/28"    # the cluster master's private IP will be assigned from this CIDR - https://cloud.google.com/nat/docs/gke-example#step_2_create_a_private_cluster
+  master_private_ip_cidr = "172.16.0.0/28"    # the cluster master's private IP will be assigned from this CIDR - https://cloud.google.com/nat/docs/gke-example#step_2_create_a_private_cluster 
   pre_defined_sa_roles = [
     "roles/logging.logWriter",
     "roles/monitoring.metricWriter",

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ locals {
   cluster_firewall_name  = format("%s-%s", var.firewall_name, var.name_suffix)
   node_network_tags      = [format("gke-%s-np-tf-%s", local.cluster_name, random_string.network_tag_substring.result)]
   oauth_scopes           = ["cloud-platform"] # FULL ACCESS to all GCloud services. Limit them by IAM roles in 'gke_service_account' - see https://cloud.google.com/compute/docs/access/service-accounts#accesscopesiam
-  master_private_ip_cidr = "172.16.0.32/28"   # the cluster master's private IP will be assigned from this CIDR - https://cloud.google.com/nat/docs/gke-example#step_2_create_a_private_cluster
+  master_private_ip_cidr = "172.16.0.0/28"   # the cluster master's private IP will be assigned from this CIDR - https://cloud.google.com/nat/docs/gke-example#step_2_create_a_private_cluster
   pre_defined_sa_roles = [
     "roles/logging.logWriter",
     "roles/monitoring.metricWriter",

--- a/variables.tf
+++ b/variables.tf
@@ -217,8 +217,8 @@ variable "node_pools" {
   and k8s.io/ prefixes are reserved by Kubernetes Core components and cannot be specified.
   See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#labels.
 
-  node_taints: Kubernetes taint to be applied to the each node of the nodepool. Supported values for
-  effect are NO_SCHEDULE, PREFER_NO_SCHEDULE, NO_EXECUTE.
+  node_taints: Kubernetes taint to be applied to each node of the nodepool. Supported values for
+  `effect` are `NO_SCHEDULE`, `PREFER_NO_SCHEDULE` or `NO_EXECUTE`.
   See https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
   
   max_pods_per_node: The maximum number of pods per node in this node pool. This value has direct

--- a/variables.tf
+++ b/variables.tf
@@ -252,6 +252,7 @@ variable "node_pools" {
     node_count_min_per_zone     = number
     node_count_max_per_zone     = number
     node_labels                 = map(string)
+    node_taints                 = list(object({ key = string, value = string, effect = string }))
     max_pods_per_node           = number
     machine_type                = string
     disk_type                   = string
@@ -268,6 +269,7 @@ variable "node_pools" {
     node_count_min_per_zone     = 1
     node_count_max_per_zone     = 2
     node_labels                 = {}
+    node_taints                 = []
     max_pods_per_node           = 32
     machine_type                = "e2-micro"
     disk_type                   = "pd-standard"

--- a/variables.tf
+++ b/variables.tf
@@ -216,6 +216,10 @@ variable "node_pools" {
   node_labels: Kubernetes labels (key-value pairs) to be applied to each node. The kubernetes.io/
   and k8s.io/ prefixes are reserved by Kubernetes Core components and cannot be specified.
   See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#labels.
+
+  node_taints: Kubernetes taint to be applied to the each node of the nodepool. Supported values for
+  effect are NO_SCHEDULE, PREFER_NO_SCHEDULE, NO_EXECUTE.
+  See https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
   
   max_pods_per_node: The maximum number of pods per node in this node pool. This value has direct
   correlation with the IP range sizes availble in "var.pods_ip_range_name".


### PR DESCRIPTION
Support for [Node taints](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).

* Allow specifying [taint](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#taint) attribute for google_container_cluster resource.