### PR TITLE
Node/Master version management

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -90,7 +90,7 @@ resource "google_container_cluster" "k8s_cluster" {
   node_locations           = local.node_locations
   network                  = var.vpc_network
   subnetwork               = var.vpc_subnetwork
-  min_master_version       = var.gke_master_version
+  min_master_version       = var.min_master_version
   logging_service          = var.cluster_logging_service
   monitoring_service       = var.cluster_monitoring_service
   enable_shielded_nodes    = var.enable_shielded_nodes

--- a/main.tf
+++ b/main.tf
@@ -27,11 +27,6 @@ locals {
         ["bad location_type"] # will force an error
   )))
 
-  # DO NOT rely on google_container_cluster.k8s_cluster.master_version to determine the value of gke_node_version.
-  # Otherwise, a RE-RUN of 'terraform apply' will be required for the changes
-  # to first be applied on the k8s masters, and then for that change to be detected (and applied) on the k8s nodes.
-  gke_node_version = var.gke_master_version
-
   predefined_node_labels = { TF_used_for = "gke", TF_used_by = google_container_cluster.k8s_cluster.name }
 
   k8s_secrets = flatten([
@@ -149,7 +144,6 @@ resource "google_container_node_pool" "node_pools" {
   provider           = google-beta
   name               = each.value.node_pool_name
   location           = local.gke_location
-  version            = local.gke_node_version
   cluster            = google_container_cluster.k8s_cluster.name
   initial_node_count = each.value.node_count_min_per_zone
   max_pods_per_node  = each.value.max_pods_per_node
@@ -159,7 +153,7 @@ resource "google_container_node_pool" "node_pools" {
   }
   management {
     auto_repair  = true
-    auto_upgrade = false
+    auto_upgrade = true # keeps the node version up-to-date with the cluster master version
   }
   upgrade_settings {
     max_surge       = each.value.max_surge

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,3 +15,8 @@ output "cluster_ca_certificate" {
   description = "Base64 encoded public certificate that is the root of trust for this cluster. Used for connecting to the cluster master via the \"cluster_endpoint\" attribute."
   value       = base64decode(google_container_cluster.k8s_cluster.master_auth.0.cluster_ca_certificate)
 }
+
+output "current_master_version" {
+  description = "Current version number of the GKE cluster master (a.k.a. the control-plane)."
+  value       = google_container_cluster.k8s_cluster.master_version
+}

--- a/variables.tf
+++ b/variables.tf
@@ -78,9 +78,9 @@ variable "sa_name" {
 }
 
 variable "min_master_version" {
-  description = "The \"minimum\" version number that should be used by the GKE cluster master (a.k.a control-plane). Note that, this is not the same as the \"current\" version number of the cluster master which maybe higher than the \"min_master_version\" specified here. To get the current version number of the cluster master, see the output of the module attribute \"current_master_version\". See https://cloud.google.com/kubernetes-engine/docs/release-notes."
+  description = "The \"minimum\" version number that should be used by the GKE cluster master (a.k.a control-plane). Note that, this is not the same as the \"current\" version number of the cluster master which maybe higher than the \"min_master_version\" specified here. To get the current version number of the cluster master, see the output of the module attribute \"current_master_version\". See https://cloud.google.com/kubernetes-engine/docs/release-notes-stable."
   type        = string
-  default     = "1.17.17-gke.2800"
+  default     = "1.18.17-gke.1900"
 }
 
 variable "cluster_description" {

--- a/variables.tf
+++ b/variables.tf
@@ -78,7 +78,7 @@ variable "sa_name" {
 }
 
 variable "min_master_version" {
-  description = "The \"minimum\" version number that should be used by the GKE cluster master (a.k.a control-plane). Note that, this is not the same as the \"current\" version number of the cluster master which maybe higher than the \"min_master_version\" specified here. See https://cloud.google.com/kubernetes-engine/docs/release-notes."
+  description = "The \"minimum\" version number that should be used by the GKE cluster master (a.k.a control-plane). Note that, this is not the same as the \"current\" version number of the cluster master which maybe higher than the \"min_master_version\" specified here. To get the current version number of the cluster master, see the output of the module attribute \"current_master_version\". See https://cloud.google.com/kubernetes-engine/docs/release-notes."
   type        = string
   default     = "1.17.17-gke.2800"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -119,7 +119,7 @@ variable "master_authorized_networks" {
 variable "enable_shielded_nodes" {
   description = "Enable Shielded Nodes feature on all nodes in the cluster. Toggling this value will drain, delete, and recreate all nodes in all node pools of this cluster. This may take a lot of time, depending on cluster size, usage and maintenance windows."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "enable_public_endpoint" {

--- a/variables.tf
+++ b/variables.tf
@@ -77,8 +77,8 @@ variable "sa_name" {
   default     = "gke"
 }
 
-variable "gke_master_version" {
-  description = "GKE version of the cluster master to be used. See https://cloud.google.com/kubernetes-engine/docs/release-notes. "
+variable "min_master_version" {
+  description = "The \"minimum\" version number that should be used by the GKE cluster master (a.k.a control-plane). Note that, this is not the same as the \"current\" version number of the cluster master which maybe higher than the \"min_master_version\" specified here. See https://cloud.google.com/kubernetes-engine/docs/release-notes."
   type        = string
   default     = "1.17.17-gke.2800"
 }


### PR DESCRIPTION
The changes in this MR will help achieve standard compliance requirements.

Commit-by-Commit:
1. Use `auto_upgrade = true` for node versions instead of specifying node version
2. Rename `var.gke_master_version` -> `var.min_master_version` to accurately describe the variable
3. New output `current_master_version`
4. Update default value for `var.min_master_version` to latest stable version as of today
5. Set `var.enable_shielded_nodes = true` by default

---

This is what is shown by GKE console when auto-upgrade is turned on for a node-pool

<img width="361" alt="Screenshot 2021-06-15 at 11 36 47 PM" src="https://user-images.githubusercontent.com/975768/122082546-ab25cd00-ce32-11eb-9828-5461d809a0f9.png">

Having auto-upgrade enabled for node-pools will not automatically upgrade the node versions to a version above what we have explicitly defined for the cluster master.