### PR TITLE
Update nginx ingress support for Kubernetes v1.22

### DIFF
--- a/helm/nginx-ingress-values.yaml
+++ b/helm/nginx-ingress-values.yaml
@@ -12,9 +12,6 @@ controller:
   image:
     registry: k8s.gcr.io
     image: ingress-nginx/controller
-    # for backwards compatibility consider setting the full image url via the repository value below
-    # use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
-    # repository:
     tag: "v1.0.0"
     digest: sha256:0851b34f69f69352bf168e6ccf30e1e20714a264ab1ecd1933e4d8c0fc3215c6
     pullPolicy: IfNotPresent
@@ -336,18 +333,6 @@ controller:
     targetCPUUtilizationPercentage: 50
     targetMemoryUtilizationPercentage: 50
     behavior: {}
-      # scaleDown:
-      #   stabilizationWindowSeconds: 300
-      #  policies:
-      #   - type: Pods
-      #     value: 1
-      #     periodSeconds: 180
-      # scaleUp:
-      #   stabilizationWindowSeconds: 300
-      #   policies:
-      #   - type: Pods
-      #     value: 2
-      #     periodSeconds: 60
 
   autoscalingTemplate: []
   # Custom or additional autoscaling metrics
@@ -544,12 +529,6 @@ controller:
 
     createSecretJob:
       resources: {}
-        # limits:
-        #   cpu: 10m
-        #   memory: 20Mi
-        # requests:
-        #   cpu: 10m
-        #   memory: 20Mi
 
     patchWebhookJob:
       resources: {}
@@ -559,9 +538,6 @@ controller:
       image:
         registry: k8s.gcr.io
         image: ingress-nginx/kube-webhook-certgen
-        # for backwards compatibility consider setting the full image url via the repository value below
-        # use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
-        # repository:
         tag: v1.0
         digest: sha256:f3b6b39a6062328c095337b4cadcefd1612348fdd5190b1dcbcb9b9e90bd8068
         pullPolicy: IfNotPresent
@@ -681,9 +657,6 @@ defaultBackend:
   image:
     registry: k8s.gcr.io
     image: defaultbackend-amd64
-    # for backwards compatibility consider setting the full image url via the repository value below
-    # use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
-    # repository:
     tag: "1.5"
     pullPolicy: IfNotPresent
     # nobody user -> uid 65534

--- a/helm/nginx-ingress-values.yaml
+++ b/helm/nginx-ingress-values.yaml
@@ -1,5 +1,5 @@
 ## nginx configuration
-## Ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/index.md
+## Ref: https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/index.md
 ##
 
 ## Overrides for generated resource names
@@ -10,9 +10,13 @@ fullnameOverride: nginx-ingress
 controller:
   name: controller
   image:
-    repository: k8s.gcr.io/ingress-nginx/controller
-    tag: "v0.46.0"
-    digest: sha256:52f0058bed0a17ab0fb35628ba97e8d52b5d32299fbc03cc0f6c7b9ff036b61a
+    registry: k8s.gcr.io
+    image: ingress-nginx/controller
+    # for backwards compatibility consider setting the full image url via the repository value below
+    # use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
+    # repository:
+    tag: "v1.0.0"
+    digest: sha256:0851b34f69f69352bf168e6ccf30e1e20714a264ab1ecd1933e4d8c0fc3215c6
     pullPolicy: IfNotPresent
     # www-data -> uid 101
     runAsUser: 101
@@ -36,7 +40,7 @@ controller:
   ##
   configAnnotations: {}
 
-  # Will add custom headers before sending traffic to backends according to https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers
+  # Will add custom headers before sending traffic to backends according to https://github.com/kubernetes/ingress-nginx/tree/main/docs/examples/customization/custom-headers
   proxySetHeaders: {}
 
   # Will add custom headers before sending response traffic to the client according to: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#add-headers
@@ -53,6 +57,11 @@ controller:
   # Bare-metal considerations via the host network https://kubernetes.github.io/ingress-nginx/deploy/baremetal/#via-the-host-network
   # Ingress status was blank because there is no Service exposing the NGINX Ingress controller in a configuration using the host network, the default --publish-service flag used in standard cloud setups does not apply
   reportNodeInternalIp: false
+
+  # Process Ingress objects without ingressClass annotation/ingressClassName field
+  # Overrides value for --watch-ingress-without-class flag of the controller binary
+  # Defaults to false
+  watchIngressWithoutClass: false
 
   # Required for use with CNI based kubernetes installations (such as ones set up by kubeadm),
   # since CNI and hostport don't mix yet. Can be deprecated once https://github.com/kubernetes/kubernetes/issues/23920
@@ -72,9 +81,18 @@ controller:
   ##
   electionID: ingress-controller-leader
 
-  ## Name of the ingress class to route through this controller
-  ##
-  ingressClass: nginx
+  # This section refers to the creation of the IngressClass resource
+  # IngressClass resources are supported since k8s >= 1.18 and required since k8s >= 1.19
+  ingressClassResource:
+    name: nginx
+    enabled: true
+    default: false
+    controllerValue: "k8s.io/ingress-nginx"
+
+    # Parameters is a link to a custom resource containing additional
+    # configuration for the controller. This is optional if the controller
+    # does not require extra parameters.
+    parameters: {}
 
   # labels to add to the pod container metadata
   podLabels: {}
@@ -317,6 +335,19 @@ controller:
     maxReplicas: 11
     targetCPUUtilizationPercentage: 50
     targetMemoryUtilizationPercentage: 50
+    behavior: {}
+      # scaleDown:
+      #   stabilizationWindowSeconds: 300
+      #  policies:
+      #   - type: Pods
+      #     value: 1
+      #     periodSeconds: 180
+      # scaleUp:
+      #   stabilizationWindowSeconds: 300
+      #   policies:
+      #   - type: Pods
+      #     value: 2
+      #     periodSeconds: 60
 
   autoscalingTemplate: []
   # Custom or additional autoscaling metrics
@@ -511,11 +542,28 @@ controller:
       servicePort: 443
       type: ClusterIP
 
+    createSecretJob:
+      resources: {}
+        # limits:
+        #   cpu: 10m
+        #   memory: 20Mi
+        # requests:
+        #   cpu: 10m
+        #   memory: 20Mi
+
+    patchWebhookJob:
+      resources: {}
+
     patch:
       enabled: true
       image:
-        repository: docker.io/jettech/kube-webhook-certgen
-        tag: v1.5.1
+        registry: k8s.gcr.io
+        image: ingress-nginx/kube-webhook-certgen
+        # for backwards compatibility consider setting the full image url via the repository value below
+        # use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
+        # repository:
+        tag: v1.0
+        digest: sha256:f3b6b39a6062328c095337b4cadcefd1612348fdd5190b1dcbcb9b9e90bd8068
         pullPolicy: IfNotPresent
       ## Provide a priority class name to the webhook patching job
       ##
@@ -631,7 +679,11 @@ defaultBackend:
 
   name: defaultbackend
   image:
-    repository: k8s.gcr.io/defaultbackend-amd64
+    registry: k8s.gcr.io
+    image: defaultbackend-amd64
+    # for backwards compatibility consider setting the full image url via the repository value below
+    # use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
+    # repository:
     tag: "1.5"
     pullPolicy: IfNotPresent
     # nobody user -> uid 65534
@@ -723,6 +775,7 @@ defaultBackend:
   #    emptyDir: {}
 
   autoscaling:
+    annotations: {}
     enabled: false
     minReplicas: 1
     maxReplicas: 2
@@ -746,7 +799,7 @@ defaultBackend:
 
   priorityClassName: ""
 
-## Enable RBAC as per https://github.com/kubernetes/ingress/tree/master/examples/rbac/nginx and https://github.com/kubernetes/ingress/issues/266
+## Enable RBAC as per https://github.com/kubernetes/ingress-nginx/blob/main/docs/deploy/rbac.md and https://github.com/kubernetes/ingress-nginx/issues/266
 rbac:
   create: true
   scope: false
@@ -767,19 +820,18 @@ imagePullSecrets: []
 # - name: secretName
 
 # TCP service key:value pairs
-# Ref: https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx/examples/tcp
+# Ref: https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/exposing-tcp-udp-services.md
 ##
 tcp: {}
 #  8080: "default/example-tcp-svc:9000"
 
 # UDP service key:value pairs
-# Ref: https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx/examples/udp
+# Ref: https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/exposing-tcp-udp-services.md
 ##
 udp: {}
 #  53: "kube-system/kube-dns:53"
 
 # A base64ed Diffie-Hellman parameter
 # This can be generated with: openssl dhparam 4096 2> /dev/null | base64
-# Ref: https://github.com/krmichel/ingress-nginx/blob/master/docs/examples/customization/ssl-dh-param
+# Ref: https://github.com/kubernetes/ingress-nginx/tree/main/docs/examples/customization/ssl-dh-param
 dhParam:
-

--- a/main.tf
+++ b/main.tf
@@ -258,7 +258,7 @@ resource "helm_release" "nginx_ingress_controller" {
   create_namespace = true
   repository       = "https://kubernetes.github.io/ingress-nginx"
   chart            = "ingress-nginx"
-  version          = "3.31.0"
+  version          = "4.0.1"
   values = [
     # values.yaml file contents copied from official repo at https://github.com/kubernetes/ingress-nginx/releases/tag/helm-chart-3.31.0
     file("${path.module}/helm/nginx-ingress-values.yaml")

--- a/main.tf
+++ b/main.tf
@@ -260,7 +260,7 @@ resource "helm_release" "nginx_ingress_controller" {
   chart            = "ingress-nginx"
   version          = "4.0.1"
   values = [
-    # values.yaml file contents copied from official repo at https://github.com/kubernetes/ingress-nginx/releases/tag/helm-chart-3.31.0
+    # values.yaml file contents copied from official repo at https://github.com/kubernetes/ingress-nginx/releases/tag/helm-chart-4.0.1
     file("${path.module}/helm/nginx-ingress-values.yaml")
   ]
   set_sensitive {


### PR DESCRIPTION
Update nginx ingress to v1.0.0 - helm chart to v4.0.1
Nginx ingress release note:
https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.0.0