### PR TITLE
Add Variable "location_policy" in node pools

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -112,7 +112,7 @@ resource "google_container_cluster" "k8s_cluster" {
   remove_default_node_pool  = true # remove the default_node_pool immediately as we will use a custom node_pool - see https://www.terraform.io/docs/providers/google/r/container_cluster.html#remove_default_node_pool
   private_cluster_config {
     enable_private_nodes    = true
-    enable_private_endpoint = ! var.enable_public_endpoint # see https://stackoverflow.com/a/57814380/636762
+    enable_private_endpoint = !var.enable_public_endpoint # see https://stackoverflow.com/a/57814380/636762
     master_ipv4_cidr_block  = var.master_private_ip_cidr
   }
   ip_allocation_policy {
@@ -134,10 +134,10 @@ resource "google_container_cluster" "k8s_cluster" {
   }
   addons_config {
     http_load_balancing {
-      disabled = ! var.enable_addon_http_load_balancing
+      disabled = !var.enable_addon_http_load_balancing
     }
     horizontal_pod_autoscaling {
-      disabled = ! var.enable_addon_horizontal_pod_autoscaling
+      disabled = !var.enable_addon_horizontal_pod_autoscaling
     }
     dns_cache_config { #see: https://cloud.google.com/kubernetes-engine/docs/how-to/nodelocal-dns-cache
       enabled = var.enable_addon_dns_cache_config
@@ -168,8 +168,8 @@ resource "google_container_node_pool" "node_pools" {
   initial_node_count = each.value.node_count_min_per_zone
   max_pods_per_node  = each.value.max_pods_per_node
   autoscaling {
-    min_node_count = each.value.node_count_min_per_zone
-    max_node_count = each.value.node_count_max_per_zone
+    min_node_count  = each.value.node_count_min_per_zone
+    max_node_count  = each.value.node_count_max_per_zone
     location_policy = var.location_policy
   }
   management {

--- a/main.tf
+++ b/main.tf
@@ -170,6 +170,7 @@ resource "google_container_node_pool" "node_pools" {
   autoscaling {
     min_node_count = each.value.node_count_min_per_zone
     max_node_count = each.value.node_count_max_per_zone
+    location_policy = var.location_policy
   }
   management {
     auto_repair  = true

--- a/variables.tf
+++ b/variables.tf
@@ -362,3 +362,9 @@ variable "master_private_ip_cidr" {
   type        = string
   default     = "172.16.0.0/28"
 }
+
+variable "location_policy" {
+  description = "Location policy specifies the algorithm used when scaling-up the node pool. Location policy is supported only in 1.24.1+ clusters."
+  type        = string
+  default     = "BALANCED"
+}


### PR DESCRIPTION
Introducing variable location_policy and setting the default value "BALANCED"
This needed for the gke cluster 1.24.+ version and above