### PR TITLE
Feature to enable security bulletin notifications

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -391,3 +391,9 @@ variable "security_group_name" {
   }
   default = null
 }
+
+variable "security_bulletins_topic" {
+  description = "The ID of pubsub topic to send security bulletin notifications. Must be in the same project as the cluster."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
This feature is added following the doc for [hardening cluster's security](https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#enable_security_bulletin_notifications).

