### PR TITLE
Add resource labels to nodes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -36,7 +36,7 @@ locals {
         ["bad location_type"] # will force an error
   )))
 
-  predefined_node_labels = { TF_used_for = "gke", TF_used_by = google_container_cluster.k8s_cluster.name }
+  predefined_node_resource_labels = { TF_used_for = "gke", TF_used_by = google_container_cluster.k8s_cluster.name }
 
   k8s_secrets = flatten([
     for namespace_obj in var.namespaces : [
@@ -234,7 +234,7 @@ resource "google_container_node_pool" "node_pools" {
     # GKE automatically adds several resource labels to node pools. They should not be modified or deleted.
     # see https://cloud.google.com/kubernetes-engine/docs/how-to/creating-managing-labels#automatically-applied-labels
     resource_labels = merge(
-      local.predefined_node_labels,
+      local.predefined_node_resource_labels,
       { goog-gke-node-pool-provisioning-model = each.value.spot ? "spot" : "on-demand" },
       try(each.value.node_resource_labels, {})
     )

--- a/main.tf
+++ b/main.tf
@@ -231,7 +231,7 @@ resource "google_container_node_pool" "node_pools" {
     labels       = merge(local.predefined_node_labels, each.value.node_labels)
     resource_labels = merge(
       { goog-gke-node-pool-provisioning-model = each.value.spot ? "spot" : "on-demand" },
-    each.value.node_resource_labels)
+    try(each.value.node_resource_labels, {}))
     service_account = module.gke_service_account.email
     oauth_scopes    = local.oauth_scopes
     tags            = distinct(concat(local.default_network_tags, each.value.network_tags))

--- a/main.tf
+++ b/main.tf
@@ -229,7 +229,9 @@ resource "google_container_node_pool" "node_pools" {
     preemptible     = each.value.preemptible
     spot            = each.value.spot
     labels          = merge(local.predefined_node_labels, each.value.node_labels)
-    resource_labels = each.value.node_resource_labels
+   resource_labels = merge(
+    { goog-gke-node-pool-provisioning-model = each.value.spot ? "spot" : "on-demand" },
+    each.value.node_resource_labels )
     service_account = module.gke_service_account.email
     oauth_scopes    = local.oauth_scopes
     tags            = distinct(concat(local.default_network_tags, each.value.network_tags))

--- a/main.tf
+++ b/main.tf
@@ -228,10 +228,16 @@ resource "google_container_node_pool" "node_pools" {
     disk_size_gb = each.value.disk_size_gb
     preemptible  = each.value.preemptible
     spot         = each.value.spot
-    labels       = merge(local.predefined_node_labels, each.value.node_labels)
+    # Kubernetes node labels that can be used in node selectors to control how workloads are scheduled to nodes
+    labels = each.value.node_labels
+    # Resource labels are used to manage resources in GCP organization and to breakdown resources.
+    # GKE automatically adds several resource labels to node pools. They should not be modified or deleted.
+    # see https://cloud.google.com/kubernetes-engine/docs/how-to/creating-managing-labels#automatically-applied-labels
     resource_labels = merge(
+      local.predefined_node_labels,
       { goog-gke-node-pool-provisioning-model = each.value.spot ? "spot" : "on-demand" },
-    try(each.value.node_resource_labels, {}))
+      try(each.value.node_resource_labels, {})
+    )
     service_account = module.gke_service_account.email
     oauth_scopes    = local.oauth_scopes
     tags            = distinct(concat(local.default_network_tags, each.value.network_tags))

--- a/main.tf
+++ b/main.tf
@@ -223,15 +223,15 @@ resource "google_container_node_pool" "node_pools" {
     }
   }
   node_config {
-    machine_type    = each.value.machine_type
-    disk_type       = each.value.disk_type
-    disk_size_gb    = each.value.disk_size_gb
-    preemptible     = each.value.preemptible
-    spot            = each.value.spot
-    labels          = merge(local.predefined_node_labels, each.value.node_labels)
-   resource_labels = merge(
-    { goog-gke-node-pool-provisioning-model = each.value.spot ? "spot" : "on-demand" },
-    each.value.node_resource_labels )
+    machine_type = each.value.machine_type
+    disk_type    = each.value.disk_type
+    disk_size_gb = each.value.disk_size_gb
+    preemptible  = each.value.preemptible
+    spot         = each.value.spot
+    labels       = merge(local.predefined_node_labels, each.value.node_labels)
+    resource_labels = merge(
+      { goog-gke-node-pool-provisioning-model = each.value.spot ? "spot" : "on-demand" },
+    each.value.node_resource_labels)
     service_account = module.gke_service_account.email
     oauth_scopes    = local.oauth_scopes
     tags            = distinct(concat(local.default_network_tags, each.value.network_tags))

--- a/main.tf
+++ b/main.tf
@@ -229,6 +229,7 @@ resource "google_container_node_pool" "node_pools" {
     preemptible     = each.value.preemptible
     spot            = each.value.spot
     labels          = merge(local.predefined_node_labels, each.value.node_labels)
+    resource_labels = each.value.node_resource_labels
     service_account = module.gke_service_account.email
     oauth_scopes    = local.oauth_scopes
     tags            = distinct(concat(local.default_network_tags, each.value.network_tags))

--- a/variables.tf
+++ b/variables.tf
@@ -330,7 +330,7 @@ variable "node_pools" {
     node_count_min_per_zone    = 1
     node_count_max_per_zone    = 2
     node_labels                = {}
-    node_resource_labels       = []
+    node_resource_labels       = {}
     node_taints                = []
     max_pods_per_node          = 16
     network_tags               = []

--- a/variables.tf
+++ b/variables.tf
@@ -329,8 +329,8 @@ variable "node_pools" {
     node_pool_name             = "gkenp-a"
     node_count_min_per_zone    = 1
     node_count_max_per_zone    = 2
-    node_labels                = {}
     node_resource_labels       = {}
+    node_labels                = {}
     node_taints                = []
     max_pods_per_node          = 16
     network_tags               = []

--- a/variables.tf
+++ b/variables.tf
@@ -247,6 +247,11 @@ variable "node_pools" {
   
   node_count_max_per_zone: The maximum number of nodes (per zone) this nodepool will allocate if
   auto-up-scaling occurs.
+
+  node_resource_labels: The GCE resource labels (a map of key/value pairs) to be applied to the nodes.
+  Resource labels are applied to all nodes and persistent disks in the node pool. It can be used to track information
+  about billing and usage. GKE automatically adds several resource labels to node pools. They should not be modified or deleted.
+  See https://cloud.google.com/kubernetes-engine/docs/how-to/creating-managing-labels#automatically-applied-labels
   
   node_labels: Kubernetes labels (key-value pairs) to be applied to each node. The kubernetes.io/
   and k8s.io/ prefixes are reserved by Kubernetes Core components and cannot be specified.

--- a/variables.tf
+++ b/variables.tf
@@ -306,8 +306,8 @@ variable "node_pools" {
     node_pool_name             = string
     node_count_min_per_zone    = number
     node_count_max_per_zone    = number
-    node_labels                = map(string)
     node_resource_labels       = optional(map(string), {})
+    node_labels                = map(string)
     node_taints                = list(object({ key = string, value = string, effect = string }))
     max_pods_per_node          = number
     network_tags               = list(string)

--- a/variables.tf
+++ b/variables.tf
@@ -307,6 +307,7 @@ variable "node_pools" {
     node_count_min_per_zone    = number
     node_count_max_per_zone    = number
     node_labels                = map(string)
+    node_resource_labels       = map(string)
     node_taints                = list(object({ key = string, value = string, effect = string }))
     max_pods_per_node          = number
     network_tags               = list(string)
@@ -329,6 +330,7 @@ variable "node_pools" {
     node_count_min_per_zone    = 1
     node_count_max_per_zone    = 2
     node_labels                = {}
+    node_resource_labels       = []
     node_taints                = []
     max_pods_per_node          = 16
     network_tags               = []

--- a/variables.tf
+++ b/variables.tf
@@ -307,7 +307,7 @@ variable "node_pools" {
     node_count_min_per_zone    = number
     node_count_max_per_zone    = number
     node_labels                = map(string)
-    node_resource_labels       = map(string)
+    node_resource_labels       = optional(map(string), {})
     node_taints                = list(object({ key = string, value = string, effect = string }))
     max_pods_per_node          = number
     network_tags               = list(string)


### PR DESCRIPTION
Fix for googleapi 400 error during terraform apply

```
Error: googleapi: Error 400: At least one of ['node_version', 'image_type', 'updated_node_pool', 'locations', 'workload_metadata_config', 'upgrade_settings', 'kubelet_config', 'linux_node_config', 'tags', 'taints', 'labels', 'node_network_config', 'gcfs_config', 'gvnic', 'confidential_nodes', 'logging_config', 'fast_socket', 'resource_labels', 'accelerators', 'windows_node_config', 'machine_type', 'disk_type', 'disk_size_gb', 'boot_disk', 'storage_pools', 'containerd_config', 'resource_manager_tags', 'performance_monitoring_unit', 'queued_provisioning', 'max_run_duration', 'flex_start'] must be specified.
```