### PR TITLE
Updates kubelet_config to follow required variable formats by Google provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,43 @@ provider "helm" {
 
 Pay attention to the `gke_cluster` module output variables used here.
 
+## kubelet_config Configuration
+This module supports kubelet configuration through the `kubelet_config` parameter in `node_pools`.
+
+### Supported Parameters
+The parameters are compatible with Google provider versions 4.55.0 to 5.43.1.
+
+| Parameter | Type | Description                                       | Default |
+|-----------|------|---------------------------------------------------|---------|
+| `cpu_manager_policy` | string | CPU management policy. Values: "none" or "static" | "none" |
+| `cpu_cfs_quota` | bool | Enable CPU CFS quota enforcement for containers   | null |
+| `cpu_cfs_quota_period` | string | CFS quota period. between "1ms" to "1000ms"       | null |
+| `pod_pids_limit` | number | Maximum PIDs per pod. Range: 1024-4194304         | null |
+
+- **Google provider 5.44.0+** introduced additional kubelet parameters that are not supported by this module version
+- If you need newer kubelet features, the module will require updates that may break backward compatibility
+
+### Configuration Block Defaults
+- `kubelet_config = null`: No kubelet configuration is applied (uses GKE defaults)
+- `kubelet_config = {}`: Creates kubelet config block with `cpu_manager_policy = "none"`
+- All parameters are optional except `cpu_manager_policy` which defaults to "none" when kubelet_config block is created
+
+### Usage Example
+```terraform
+module "gke_cluster" {
+  source = "airasia/gke_cluster/google"
+  node_pools = [{
+    # ... other node pool configuration
+    kubelet_config = {
+      cpu_manager_policy   = "static"        # string
+      cpu_cfs_quota        = true            # bool  
+      cpu_cfs_quota_period = "100ms"         # string
+      pod_pids_limit       = 2048            # number
+    }
+  }]
+}
+```
+
 # Upgrade guide from v2.15.0 to v2.16.0
 
 Drop the use of attributes such as `node_count_initial_per_zone` and/or `node_count_current_per_zone` (if any) from the list of objects in `var.node_pools`.

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ The parameters are compatible with Google provider versions 4.55.0 to 5.43.1.
 
 ### Configuration Block Defaults
 - `kubelet_config = null`: No kubelet configuration is applied (uses GKE defaults)
-- `kubelet_config = {}`: Creates kubelet config block with `cpu_manager_policy = "none"`
-- All parameters are optional except `cpu_manager_policy` which defaults to "none" when kubelet_config block is created
+- `kubelet_config = {}`: Creates kubelet config block with `cpu_manager_policy = ""` (empty string)
+- All parameters are optional except `cpu_manager_policy` which defaults to empty string when kubelet_config block is created
+- Empty string for `cpu_manager_policy` prevents permadrift (a bug fixed in Google provider v6.4.0)
 
 ### Usage Example
 ```terraform

--- a/main.tf
+++ b/main.tf
@@ -269,14 +269,16 @@ resource "google_container_node_pool" "node_pools" {
     }
     dynamic "kubelet_config" {
       # Kubelet configuration supported attributes available in provider 4.85.0
-      # https://registry.terraform.io/providers/hashicorp/google/4.85.0/docs/resources/container_cluster#nested_kubelet_config
+      # See https://registry.terraform.io/providers/hashicorp/google/4.85.0/docs/resources/container_cluster#nested_kubelet_config
+      # See https://cloud.google.com/kubernetes-engine/docs/how-to/node-system-config#kubelet-options
       for_each = each.value.kubelet_config == null ? [] : [each.value.kubelet_config]
       iterator = kubelet_config
       content {
-        cpu_manager_policy   = coalesce(lookup(kubelet_config.value, "cpu_manager_policy", null), "none") # string
-        cpu_cfs_quota        = lookup(kubelet_config.value, "cpu_cfs_quota", null)                        # boolean
-        cpu_cfs_quota_period = lookup(kubelet_config.value, "cpu_cfs_quota_period", null)                 # string
-        pod_pids_limit       = lookup(kubelet_config.value, "pod_pids_limit", null)                       # integer
+        # cpu_manager_policy must be set when kubelet_config is, but causes permadrift unless set to undocumented empty value. Bug fixed in Google provider v6.4.0.
+        cpu_manager_policy   = lookup(kubelet_config.value, "cpu_manager_policy") != null ? lookup(kubelet_config.value, "cpu_manager_policy") : ""
+        cpu_cfs_quota        = lookup(kubelet_config.value, "cpu_cfs_quota", null)
+        cpu_cfs_quota_period = lookup(kubelet_config.value, "cpu_cfs_quota_period", null)
+        pod_pids_limit       = lookup(kubelet_config.value, "pod_pids_limit", null)
       }
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -229,7 +229,9 @@ resource "google_container_node_pool" "node_pools" {
     preemptible  = each.value.preemptible
     spot         = each.value.spot
     # Kubernetes node labels that can be used in node selectors to control how workloads are scheduled to nodes
-    labels = each.value.node_labels
+    # Predefined kubernetes labels are set to address a bug in provider when removing all labels. Bug fixed in Google provider 6.18.1.
+    # https://github.com/hashicorp/terraform-provider-google/issues/15848#issuecomment-2669370077
+    labels = merge(local.predefined_node_resource_labels, each.value.node_labels)
     # Resource labels are used to manage resources in GCP organization and to breakdown resources.
     # GKE automatically adds several resource labels to node pools. They should not be modified or deleted.
     # see https://cloud.google.com/kubernetes-engine/docs/how-to/creating-managing-labels#automatically-applied-labels

--- a/variables.tf
+++ b/variables.tf
@@ -137,10 +137,10 @@ variable "enable_public_endpoint" {
 variable "namespaces" {
   description = "A list of namespaces to be created in kubernetes. A map of secrets can be included e.g. {\"mysql\": {\"username\": \"johndoe\", \"password\": \"password123\"}}"
   type = list(object({
-    name         = string
-    labels       = map(string)
-    annotations  = map(string)
-    secrets      = map(map(string))
+    name        = string
+    labels      = map(string)
+    annotations = map(string)
+    secrets     = map(map(string))
   }))
   default = []
 }
@@ -272,7 +272,7 @@ variable "node_pools" {
   disk_type: Type of the disk for each node. Acceptable values are "pd-standard", "pd-balanced" or
   "pd-ssd". "pd-standard" is default. "pd-ssd" is costly.
   
-  disk_size_gb: Size of the disk on each node in Giga Bytes.
+  disk_size_gb: Size of the disk on each node in Giga Bytes. Minimum 12 GB.
   
   preemptible: Preemptible nodes last a maximum of 24 hours and helps reduce cost while providing no
   availability guarantee. It can be used for non-production clusters to help save cost. Not recommended
@@ -306,6 +306,13 @@ variable "node_pools" {
   gpu_type: Compute Engine provides graphics processing units (GPUs) that you can add to your virtual machine (VM) instances. You can use these GPUs to accelerate specific workloads on your VMs such as machine learning and data processing.
   See https://cloud.google.com/compute/docs/gpus & https://cloud.google.com/compute/docs/machine-resource#gpus
 
+  kubelet_config: (Optional) Kubelet configuration parameters. Can be null (no config) or a map with any of the following keys:
+  - cpu_cfs_quota (bool): Enable CPU CFS quota enforcement for containers that specify CPU limits
+  - cpu_manager_policy (string): CPU management policy. Defaults to "none". Other values: "static"
+  - pod_pids_limit (number): Maximum number of process IDs that can be run in a pod
+  Additional parameters may be passed through for future Google provider compatibility.
+  When null, no kubelet configuration is applied. When provided, cpu_manager_policy defaults to "none" if not specified.
+
   node_metadatas: Map of Compute Engine instance metadata (key-values) to be applied to all nodes in a nodepool. Instance metadata can be used to configure the behavior of the nodes / VM instances.
 
   network_config: (Optional) Specifies the network configuration for the pool. Use this if you want to override the cluster’s default network configuration.
@@ -333,7 +340,7 @@ variable "node_pools" {
     enable_gke_metadata_server = bool
     node_metadatas             = map(string)
     gpu_type                   = map(string)
-    kubelet_config             = object({ cpu_cfs_quota = bool, cpu_manager_policy = string, pod_pids_limit = number })
+    kubelet_config             = any
     network_config             = object({ pod_range = string })
     oauth_scopes               = list(string)
   }))

--- a/variables.tf
+++ b/variables.tf
@@ -306,12 +306,12 @@ variable "node_pools" {
   gpu_type: Compute Engine provides graphics processing units (GPUs) that you can add to your virtual machine (VM) instances. You can use these GPUs to accelerate specific workloads on your VMs such as machine learning and data processing.
   See https://cloud.google.com/compute/docs/gpus & https://cloud.google.com/compute/docs/machine-resource#gpus
 
-  kubelet_config: (Optional) Kubelet configuration parameters. Can be null (no config) or a map with any of the following keys:
-  - cpu_cfs_quota (bool): Enable CPU CFS quota enforcement for containers that specify CPU limits
-  - cpu_manager_policy (string): CPU management policy. Defaults to "none". Other values: "static"
-  - pod_pids_limit (number): Maximum number of process IDs that can be run in a pod
-  Additional parameters may be passed through for future Google provider compatibility.
-  When null, no kubelet configuration is applied. When provided, cpu_manager_policy defaults to "none" if not specified.
+  kubelet_config: (Optional) Kubelet configuration parameters. Can be `null` (no config) or an empty map `{}` (creates block with `cpu_manager_policy = ""`) or a map with the following supported parameters for provider 4.55.0 to 5.43.1:
+  - cpu_manager_policy (string): CPU management policy. Values: "none", "static".
+  - cpu_cfs_quota (bool): Enable CPU CFS quota enforcement for containers that specify CPU limits.
+  - cpu_cfs_quota_period (string): CFS quota period. Format: "1ms" to "1000ms".
+  - pod_pids_limit (number): Maximum PIDs per pod. Range: 1024-4194304.
+  See https://cloud.google.com/kubernetes-engine/docs/how-to/node-system-config#kubelet-options
 
   node_metadatas: Map of Compute Engine instance metadata (key-values) to be applied to all nodes in a nodepool. Instance metadata can be used to configure the behavior of the nodes / VM instances.
 


### PR DESCRIPTION
Fixes to address the following errors:
- kubelet_config: error when trying to set null to avoid permadrift caused by Google API issue (expected to be fixed in Google provider 6.18.1).
- node_labels: error when removing all existing labels caused by Google API issue (expected to be fixed in Google provider v6.4.0).

Error observed when applying changes:
```
Error: googleapi: Error 400: At least one of ['node_version', 'image_type', 'updated_node_pool', 'locations', 'workload_metadata_config', 'upgrade_settings', 'kubelet_config', 'linux_node_config', 'tags', 'taints', 'labels', 'node_network_config', 'gcfs_config', 'gvnic', 'confidential_nodes', 'logging_config', 'fast_socket', 'resource_labels', 'accelerators', 'windows_node_config', 'machine_type', 'disk_type', 'disk_size_gb', 'boot_disk', 'storage_pools', 'containerd_config', 'resource_manager_tags', 'performance_monitoring_unit', 'queued_provisioning', 'max_run_duration', 'flex_start'] must be specified.
```